### PR TITLE
Refactor: Invert pyramid and arrange hexagon content horizontally

### DIFF
--- a/app/src/components/Hexagon.css
+++ b/app/src/components/Hexagon.css
@@ -12,7 +12,7 @@
   height: 86.6px; /* sqrt(3)/2 * 100px */
   background-color: lightblue;
   display: flex;
-  flex-direction: column;
+  flex-direction: row;
   justify-content: center;
   align-items: center;
   cursor: pointer;
@@ -29,7 +29,7 @@
 .hexagon-operator {
   font-size: 1.2em; /* Adjusted for new size */
   font-weight: bold;
-  margin-bottom: 2px; /* Space between operator and number */
+  margin-right: 5px; /* Space between operator and number */
 }
 
 .hexagon-number {

--- a/app/src/components/HexagonPyramid.css
+++ b/app/src/components/HexagonPyramid.css
@@ -34,7 +34,7 @@
     The exact value needs tuning. A common value is -(hexagon height / 4 + border width).
     Our hexagon height is 86.6px. So -21.65px.
   */
-  margin-bottom: -20px; /* Adjusted for tighter packing, will need tuning */
+  margin-top: -20px; /* Adjusted for tighter packing, will need tuning */
   /*
     Horizontal offset for rows:
     Row 4 (1 hex): 0 offset
@@ -48,8 +48,8 @@
   */
 }
 
-.hexagon-row:last-child {
-  margin-bottom: 0; /* No negative margin for the last row */
+.hexagon-row:first-child {
+  margin-top: 0; /* No negative margin for the first row */
 }
 
 /*

--- a/app/src/components/HexagonPyramid.tsx
+++ b/app/src/components/HexagonPyramid.tsx
@@ -36,7 +36,7 @@ const HexagonPyramid: React.FC<HexagonPyramidProps> = ({ onHexagonClick }) => {
       return <p>Generating hexagons...</p>;
     }
 
-    const rowsDefinition = [4, 3, 2, 1]; // Hexagons per row
+    const rowsDefinition = [1, 2, 3, 4]; // Hexagons per row
     let hexagonIndex = 0;
 
     return rowsDefinition.map((hexagonsInRow, rowIndex) => (


### PR DESCRIPTION
I've inverted the hexagon pyramid structure so the rows display with an increasing number of hexagons (1, 2, 3, 4). I also adjusted the CSS for proper row packing in this new inverted layout.

Additionally, I modified the hexagon tiles so the operator and number display horizontally instead of vertically. To achieve this horizontal layout, I updated the flexbox properties and margins within the hexagon components.